### PR TITLE
Raise an exception when no sections present

### DIFF
--- a/lib/slide-em-up/presentation.rb
+++ b/lib/slide-em-up/presentation.rb
@@ -20,7 +20,7 @@ module SlideEmUp
       @meta   = build_meta(infos["title"], dir)
       @theme  = build_theme(infos["theme"])
       @common = build_theme("common")
-      @parts  = infos["sections"]
+      @parts  = infos["sections"] || raise(Exception, "check your presentation.json or showoff.json file")
       @parts  = Hash[@parts.zip @parts] if Array === @parts
     end
 

--- a/spec/slide-em-up_spec.rb
+++ b/spec/slide-em-up_spec.rb
@@ -73,4 +73,13 @@ describe SlideEmUp do
       @html.must_match /<code class="ruby">.+<\/code>/m
     end
   end
+
+  describe "no json presentation" do
+    it 'raise error with nither presentation.json or showoff.json file' do
+      proc {
+        space_dir = File.expand_path("../example1/", __FILE__)
+        @presentation = SlideEmUp::Presentation.new(space_dir)
+      }.must_raise Exception
+    end
+  end
 end


### PR DESCRIPTION
I just created a presentation_s_.json file with a typo,
i dont get any notice from my mistake and the server dont respond anything,
when I do a Ctrl-C, ive got this error:
« [:error, "undefined method `map' for nil:NilClass"] »

Maybe you will prefer « @parts  = infos["sections"] || [] »

You will have no failure but the server will respond with a content « no
title »
## 

Laurent
